### PR TITLE
small typo `keyponts` -> `keypoints`

### DIFF
--- a/examples/colab/tf2_object_detection.ipynb
+++ b/examples/colab/tf2_object_detection.ipynb
@@ -144,7 +144,7 @@
         "\n",
         "- Helper method to load an image\n",
         "- Map of Model Name to TF Hub handle\n",
-        "- List of tuples with Human Keypoints for the COCO 2017 dataset. This is needed for models with keyponts."
+        "- List of tuples with Human Keypoints for the COCO 2017 dataset. This is needed for models with keypoints."
       ]
     },
     {


### PR DESCRIPTION
PiperOrigin-RevId: 380794585